### PR TITLE
Switched Genius Armorer and Resilient Commander Bonuses

### DIFF
--- a/europe/Changelog.txt
+++ b/europe/Changelog.txt
@@ -120,7 +120,7 @@
   - Catalytic Processing can now toggle its effects through the newly added Manufacturing Policy, allowing empires to switch between using food and using minerals without needing to necessarily reform their government.
   - Citizen Service no longer gives +15% Naval Capacity. Instead, it replaces half of all Politician jobs on capital buildings with Officer jobs. It is also now incompatible with other civics that similarly replace Politicians jobs, including Merchant Guilds, Technocracy, Exalted Priesthood, and Aristocratic Elite.
   - Factions can now spawn after 6 months for everyone instead of spawning after 30 days for Parliamentary System empires and after 10 years for everyone else (and only if they encountered another player). However, the unity output of factions in general has been decreased by 33%.
-  - Parliamentary System now increases Unity from factions by +100% instead of +40%, but also gets -10% faction approval, which cancels out the faction approval bonus normally given to Democratic authority empires.
+  - Parliamentary System now increases Unity from factions by +70% instead of +40%, but also gets -10% faction approval, which cancels out the faction approval bonus normally given to Democratic authority empires.
   - Heroic Past, Precision Cogs, Factory Overclocking, and Pooled Knowledge now all also give +1 Leader Pool Size.
 24. Various changes to the faction system, mostly to fix weird niche cases and to prevent people from just promoting factions all the time.
   - Authoritarian faction is no longer angry with Decadent Lifestyle living standards or any Assimilation citizenship type, but is no longer satisfied with robotic servitude if AI is outlawed.

--- a/europe/Changelog.txt
+++ b/europe/Changelog.txt
@@ -124,3 +124,5 @@
 26. Diplomacy actions between players no longer need trust. Trust requirements for pacts with AI empires remain unchanged.
 27. AI-Spawning origins have been disabled for players.
 28. Broken Shackles has been tweaked so that it will no longer spawn MSI or a Payback empire unless another AI Broken Shackles and/or Payback empire already exists.
+29. Genius Armorer now gives +25% Ship Hull Points and +2% Daily Hull Regeneration instead of bonus Armor Hardening, Shield Hardening, Shield Points, and Armor Points. The new bonuses are the (old) effects of the Resilient Commander trait, but applied empire-wide instead of fleetwide.
+30. Resilient Commander now gives +20% Ship Shield Points, +20% Ship Armor Points, +20% Armor Hardening, and +20% Shield Hardening. These are mostly the (old) effects of Genius Armorer, but applied to a single fleet instead of empire-wide.

--- a/europe/Changelog.txt
+++ b/europe/Changelog.txt
@@ -66,7 +66,7 @@
 21. Major changes to various Traditions, generally buffing ones that are markedly underpowered and nerfing those that are seen as must-picks.
   - Subterfuge finisher now also causes completed espionage operations to return 50% of their infiltration level cost in influence.
   - Adaptibility opener now gives -10% Pop Amenities usage instead of -10% Pop Housing usage.
-  - Appropriation (under Adaptibility) now also gives +1 Building slots and -10% Pop Housing usage.
+  - Appropriation (under Adaptibility) now also gives -10% Pop Housing usage.
   - Adaptive Ecology (under Adaptibility) now also gives -5% Pop Upkeep.
   - Versatility opener now gives -20% Pop Assembly Cost and -10% Pop Housing usage instead of -10% Pop Assembly Cost.
   - Versatility finisher no longer increases the Energy upkeep of Assembler jobs.
@@ -79,27 +79,32 @@
   - Reach for the Stars (under Expansion) now also extends its -10% Outpost Influence cost to Outpost Alloy cost as well.
   - Galactic Ambitions (under Expansion) now also gives -20% orbital stations upkeep.
   - Unity of Self (under Harmony for Necrophages), Unity of Mind (under Synchronicity for Necrophages), and Self-Preservation (under Synchronicity for Machine Intelligences) now also still give the same effects as the traditions they replace, which are still important even if they are more negligible.
-  - Mind and Body (under Harmony) and Cloned Organs (under Synchronicity) now give +20 Leader Lifespan instead of +10.
   - Synthetically ascended normal empires now have Mind and Body (under Harmony) replaced with Self-Preservation (normally under Synchronicity), which means they now benefit from halved leader accident chance because they would gain no benefit from increases to Leader Lifespan.
-  - Harmonious Directives (under Harmony), Flexible Thought Routines (under Synchronicity), and Grand Council (under Domination) now give +45 flat Edict Fund and +10% Edict Fund instead of just a flat +50 Edict Fund.
+  - Harmonious Directives (under Harmony), Flexible Thought Routines (under Synchronicity), Grand Council (under Domination), and the Statecraft Opener now give +45 flat Edict Fund and +10% Edict Fund instead of just a flat +50 Edict Fund.
   - The replacements of Adaptive Economic Policies (under Mercantile) now work differently. Mega-cooperative empires no longer have the tradition replaced after entering a Trade League federation. Empires that are in a Trade League or in a tier 3 or higher Holy Covenant now replace the tradition with "Customs Union", which removes the Influence cost of Commercial Pacts with fellow federation members. Non-megacooperative megacorporation empires that have also taken Universal Transactions will replace the tradition with Trade Fleets, which has the same effect of +50% Federation Naval Capacity Contribution.
   - Prosperity opener now gives +25% Mining Station Output instead of +20%.
   - Prosperity finisher now gives its old effect of +5% Resources from Jobs instead of -10% Station Upkeep.
   - Standard Construction Templates (under Prosperity) now gives -15% Clear Blocker cost instead of -10% Building Cost.
   - Void Works (under Prosperity as alternative to Public Works for Void Dwellers) no longer gives +1 max districts on habitats.
   - Interstellar Franchising (under Prosperity) now gives -50% Empire Size from Districts instead of -5% Upkeep from Jobs.
-  - Pursuit of Profit (under Prosperity) now gives +15% Amenities from Jobs instead of +5% Resources from Jobs. The change also applies to Gestalt Consciousness equivalents of the tradition that used to give +5% Complex Drone Output.
+  - Pursuit of Profit (under Prosperity) now gives +10% Amenities from Jobs instead of +5% Resources from Jobs. The change also applies to Gestalt Consciousness equivalents of the tradition that used to give +5% Complex Drone Output.
   - Modular Depot (under Domination, only for Machine Intelligences) now gives -10% Building Cost instead of -25% Empire Size from Districts.
   - Synaptic Sub-processing (under Cybernetics, only for Hive Minds) now gives +15% Pop Assembly Speed instead of -50% Empire Size from Districts.
   - War Doctrines no longer require the Supremacy finisher to unlock.
   - Supremacy opener now gives +25% Army Morale Attack, +25% Army Morale Defense, and -20% Army Cost instead of +20% Army Damage and +20 Naval Capacity.
   - Supremacy finisher now gives +25% Ship Disengagement Chance and +25% Ship Experience Gain.
   - Logistical Corps (under Supremacy) now also gives -10% Army Upkeep.
+  - Master Shipwrights (under Supremacy) now also gives -10% Ship Retrofit Cost.
   - War Games (under Supremacy) now gives +100 Ship Starting Experience instead of +20 Fleet Command Limit.
   - Overwhelming Force (under Supremacy) now gives +25% Orbital Bombardment damage instead of +20% and gives +1 Max Influence from Power Projection, but no longer gives +10% Ship Fire Rate.
   - The Great Game (under Supremacy) now gives +20 Fleet Command limit and -20% Claim Influence Cost instead of +20% Starbase Damage.
   - Bulwark of Harmony (under Unyielding) now gives +50% Defense Platform Build Speed instead of +15% Home Territory Ship Fire Rate.
   - Direct Diplomacy (under Diplomacy) now also gives +33% Immigration Pull to all planets.
+  - Aptitude finisher and The Empire Needs You (under Aptitude) now also give +1 Leader Pool Size.
+  - Healthcare Program (under Aptitude) now also gives +10 Leader Lifespan.
+  - Specialist Training (under Aptitude) now gives +10% Leader Experience Gain instead of +1 Leader Pool Size.
+  - Information Security (under Subterfuge) now gives +2 Encryption instead of +1 Encryption, but no longer gives +5 Evasion.
+  - Operational Security (under Subterfuge) no longer gives +10 Tracking.
 22. Various changes to jobs were introduced, generally to reduce the need for micromanagement from players and as part of balancing other parts of the game.
   - Colonist jobs now give 3 Food instead of 1, and Lithoid Colonist jobs now give 2 Minerals instead of 1.
   - Soldiers no longer have massively increased weights under a Commander governor (that tends to ruin planets' economies unless you micromanage them).
@@ -111,11 +116,12 @@
   - Meritocracy now gives +1 Starting Leader Level and +1 Leader Pool size instead of +10% Specialist Resource Output.
   - Vaults of Knowledge now gives -25% Leader Upkeep instead of +1 Starting Leader Level.
   - Oppressive Autocracy now gives -25% Leader Cost instead of -25% Leader Upkeep.
-  - Distinguished Admiralty now gives +1 Commander Starting Level and +1 Commander Capacity instead of +2 Commander Starting Level.
+  - Distinguished Admiralty, Strength of Legions, and Warbots now give +1 Commander Starting Level and +1 Commander Capacity instead of +2 Commander Starting Level.
   - Catalytic Processing can now toggle its effects through the newly added Manufacturing Policy, allowing empires to switch between using food and using minerals without needing to necessarily reform their government.
   - Citizen Service no longer gives +15% Naval Capacity. Instead, it replaces half of all Politician jobs on capital buildings with Officer jobs. It is also now incompatible with other civics that similarly replace Politicians jobs, including Merchant Guilds, Technocracy, Exalted Priesthood, and Aristocratic Elite.
   - Factions can now spawn after 6 months for everyone instead of spawning after 30 days for Parliamentary System empires and after 10 years for everyone else (and only if they encountered another player). However, the unity output of factions in general has been decreased by 33%.
   - Parliamentary System now increases Unity from factions by +100% instead of +40%, but also gets -10% faction approval, which cancels out the faction approval bonus normally given to Democratic authority empires.
+  - Heroic Past, Precision Cogs, Factory Overclocking, and Pooled Knowledge now all also give +1 Leader Pool Size.
 24. Various changes to the faction system, mostly to fix weird niche cases and to prevent people from just promoting factions all the time.
   - Authoritarian faction is no longer angry with Decadent Lifestyle living standards or any Assimilation citizenship type, but is no longer satisfied with robotic servitude if AI is outlawed.
   - Spiritualist faction is no longer angry with Robots Allowed if Roboticists are set to assemble cybernetic components.

--- a/europe/common/governments/civics/99_alternative_civics.txt
+++ b/europe/common/governments/civics/99_alternative_civics.txt
@@ -393,7 +393,7 @@ civic_parliamentary_system = {
 	}
 	#description = "civic_tooltip_parliamentary_system_effects" # Europe: disabled because it's now universal for everyone
 	modifier = {
-		pop_factions_produces_mult = 1.0 # Europe: increased from 0.40, note that we also lowered base faction unity output, too, to compensate for everyone getting factions early
+		pop_factions_produces_mult = 0.70 # Europe: increased from 0.40, note that we also lowered base faction unity output, too, to compensate for everyone getting factions early
 		faction_approval = -0.10 # Europe: Parliamentary system negates the faction approval bonus from Democratic
 	}
 }

--- a/europe/common/governments/civics/99_alternative_civics.txt
+++ b/europe/common/governments/civics/99_alternative_civics.txt
@@ -223,6 +223,65 @@ civic_distinguished_admiralty = {
 	}
 }
 
+civic_hive_strength_of_legions = {
+	potential = { authority = { value = auth_hive_mind } }
+	random_weight = { base = @civic_default_random_weight }
+	ai_weight = {
+		base = @ai_civic_default_base_weight
+		modifier = {
+			factor = @ai_civic_personality_match_factor
+			OR = {
+				has_ai_personality = devouring_swarm
+			}
+		}
+	}
+#	description = "civic_tooltip_hive_strength_of_legions_effects"
+	modifier = {
+		councilor_gestalt_regulatory_exp_gain = @gestalt_civic_node_xp_rate
+		army_starting_experience_add = 100
+		army_damage_mult = 0.20
+		armies_upkeep_mult = -0.20
+		commander_initial_skill = 1 # Europe: reduced from 2
+		country_commander_cap_add = 1 # Europe: added
+	}
+}
+
+civic_machine_warbots = {
+	potential = {
+		authority = {
+			OR = {
+				value = auth_ancient_machine_intelligence
+				value = auth_machine_intelligence
+			}
+		}
+	}
+	random_weight = { base = @civic_default_random_weight }
+	ai_weight = {
+		base = @ai_civic_default_base_weight
+		modifier = {
+			factor = @ai_civic_personality_match_factor
+			OR = {
+				has_ai_personality = exterminators
+			}
+		}
+		modifier = {
+			factor = @ai_civic_personality_mismatch_factor
+			OR = {
+				has_ai_personality = servitors
+			}
+		}
+	}
+#	description = civic_tooltip_machine_warbots_effects
+	modifier = {
+		councilor_gestalt_legion_exp_gain = @gestalt_civic_node_xp_rate
+		army_damage_mult = 0.2
+		armies_upkeep_mult = -0.2
+		commander_initial_skill = 1 # Europe: reduced from 2
+		country_commander_cap_add = 1 # Europe: added
+	}
+}
+
+
 civic_citizen_service = {
 	potential = {
 		ethics = { NOT = { value = ethic_gestalt_consciousness } }
@@ -336,5 +395,90 @@ civic_parliamentary_system = {
 	modifier = {
 		pop_factions_produces_mult = 1.0 # Europe: increased from 0.40, note that we also lowered base faction unity output, too, to compensate for everyone getting factions early
 		faction_approval = -0.10 # Europe: Parliamentary system negates the faction approval bonus from Democratic
+	}
+}
+
+civic_heroic_tales = {
+	playable = { host_has_dlc = "Galactic Paragons" }
+	ai_playable = { host_has_dlc = "Galactic Paragons" }
+	random_weight = {
+		base = 4
+	}
+#	description = "civic_heroic_tales_effects"
+	potential = {
+		ethics = { NOT = { value = ethic_gestalt_consciousness } }
+		authority = { NOT = { value = auth_corporate } }
+	}
+	possible = {
+	}
+	modifier = {
+		country_official_cap_add = 1
+		country_commander_cap_add = 1
+		country_scientist_cap_add = 1
+		country_leader_pool_size = 1 # Europe: added
+	}
+}
+
+civic_hive_pooled_knowledge = {
+	potential = { authority = { value = auth_hive_mind } }
+	random_weight = { base = @civic_default_random_weight }
+	ai_weight = {
+		base = @ai_civic_default_base_weight
+		modifier = {
+			factor = @ai_civic_personality_mismatch_factor
+			OR = {
+				has_ai_personality = devouring_swarm
+			}
+		}
+	}
+	modifier = {
+		councilor_gestalt_cognitive_exp_gain = @gestalt_civic_node_xp_rate
+		country_official_cap_add = 1
+		country_commander_cap_add = 1
+		country_scientist_cap_add = 1
+		country_leader_pool_size = 1 # Europe: added
+	}
+}
+
+civic_machine_factory_overclock = {
+	icon = "gfx/interface/icons/governments/civics/civic_machine_factory_overclock.dds"
+	potential = { authority = { value = auth_machine_intelligence } }
+	random_weight = { base = @civic_default_random_weight }
+	ai_weight = {
+		base = @ai_civic_default_base_weight
+	}
+	modifier = {
+		councilor_gestalt_regulatory_exp_gain = @gestalt_civic_node_xp_rate
+		country_official_cap_add = 1
+		country_commander_cap_add = 1
+		country_scientist_cap_add = 1
+		country_leader_pool_size = 1 # Europe: added
+	}
+}
+
+civic_task_delegation_corporate = {
+	playable = { host_has_dlc = "Galactic Paragons" }
+	ai_playable = { host_has_dlc = "Galactic Paragons" }
+	random_weight = {
+		base = 4
+	}
+	potential = {
+		OR = {
+			authority = { value = auth_corporate }
+			civics = { value = civic_galactic_sovereign_megacorp }
+		}
+		ethics = {
+			NOT = {
+				value = ethic_gestalt_consciousness
+			}
+		}
+	}
+	possible = {
+	}
+	modifier = {
+		country_official_cap_add = 1
+		country_commander_cap_add = 1
+		country_scientist_cap_add = 1
+		country_leader_pool_size = 1 # Europe: added
 	}
 }

--- a/europe/common/traditions/99_alternative_adaptability.txt
+++ b/europe/common/traditions/99_alternative_adaptability.txt
@@ -28,7 +28,6 @@ tr_adaptability_appropriation = {
 	modifier = {
 		pop_resettlement_cost_mult = -0.5
 		pop_housing_usage_mult = -0.10 # Europe: added
-		planet_max_buildings_add = 1
 	}
 
 	ai_weight = {

--- a/europe/common/traditions/99_alternative_aptitude.txt
+++ b/europe/common/traditions/99_alternative_aptitude.txt
@@ -1,0 +1,77 @@
+tr_aptitude_finish = {
+	modifier = {
+		country_commander_cap_add = 1
+		country_official_cap_add = 1
+		country_scientist_cap_add = 1
+		country_leader_pool_size = 1 # Europe: added
+		ascension_perks_add = 1
+	}
+}
+
+tr_aptitude_the_empire_needs_you = {
+	modifier = {
+		leaders_cost_mult = -0.25
+		country_leader_pool_size = 1 # Europe: added
+	}
+	ai_weight = { factor = 1000 }
+
+	inline_script = {
+		script = paragon/tradition_swap_desc_hive
+		tradition = tr_aptitude_the_empire_needs_you
+	}
+	inline_script = {
+		script = paragon/tradition_swap_desc_machine
+		tradition = tr_aptitude_the_empire_needs_you
+	}
+}
+
+tr_aptitude_specialist_training = {
+	modifier = {
+		#country_leader_pool_size = 1 # Europe: removed, moved to Empire Needs You
+		species_leader_exp_gain = 0.1 # Europe: added
+	}
+	ai_weight = { factor = 1000 }
+
+	inline_script = {
+		script = paragon/tradition_swap_desc_hive
+		tradition = tr_aptitude_specialist_training
+	}
+	inline_script = {
+		script = paragon/tradition_swap_desc_machine
+		tradition = tr_aptitude_specialist_training
+	}
+}
+
+tr_aptitude_healthcare_program = {
+	custom_tooltip = BLANK_STRING	# Since the Modifier uses only a scripted modifier, we'll get an error without a custom tooltip.
+	possible = { has_tradition = tr_aptitude_the_empire_needs_you }
+	modifier = {
+		leader_lifespan_add = 10 # Europe: added
+		negative_traits_country = -1
+	}
+	ai_weight = { factor = 1000 }
+
+	tradition_swap = {
+		custom_tooltip = BLANK_STRING	# Since the Modifier uses only a scripted modifier, we'll get an error without a custom tooltip.
+		trigger = { is_hive_empire = yes }
+		name = tr_aptitude_healthcare_program_hive
+		inherit_icon = yes
+		modifier = {
+			leader_lifespan_add = 10 # Europe: added
+			negative_traits_country = -1
+		}
+		weight = { factor = 1 }
+	}
+
+	tradition_swap = {
+		custom_tooltip = BLANK_STRING	# Since the Modifier uses only a scripted modifier, we'll get an error without a custom tooltip.
+		trigger = { is_machine_empire = yes }
+		name = tr_aptitude_healthcare_program_machine
+		inherit_icon = yes
+		modifier = {
+			leader_lifespan_add = 10 # Europe: added
+			negative_traits_country = -1
+		}
+		weight = { factor = 1 }
+	}
+}

--- a/europe/common/traditions/99_alternative_harmony.txt
+++ b/europe/common/traditions/99_alternative_harmony.txt
@@ -1,7 +1,7 @@
 tr_harmony_mind_and_body = {
 
 	modifier = {
-		leader_lifespan_add = 20 # Europe: increased from 10
+		leader_lifespan_add = 10
 		negative_traits_country = -1
 	}
 
@@ -16,7 +16,7 @@ tr_harmony_mind_and_body = {
 		}
 		custom_tooltip = tr_synchronicity_self_preservation_desc
 		modifier = {
-			leader_lifespan_add = 20
+			leader_lifespan_add = 10
 			negative_traits_country = -1
 		}
 		weight = {
@@ -30,7 +30,7 @@ tr_harmony_mind_and_body = {
 		custom_tooltip = tr_harmony_unity_of_self_desc
 		# gain unity per pop necrophaged
 		modifier = { # Europe: added
-			leader_lifespan_add = 20
+			leader_lifespan_add = 10
 			negative_traits_country = -1
 		}
 		trigger = {

--- a/europe/common/traditions/99_alternative_prosperity.txt
+++ b/europe/common/traditions/99_alternative_prosperity.txt
@@ -107,7 +107,7 @@ tr_prosperity_pursuit_of_profit = {
 
 	modifier = {
 		#planet_jobs_produces_mult = 0.05 # Europe: moved back to finisher
-		planet_amenities_mult = 0.15 # Europe: added
+		planet_amenities_mult = 0.10 # Europe: added
 	}
 
 	tradition_swap = {

--- a/europe/common/traditions/99_alternative_statecraft.txt
+++ b/europe/common/traditions/99_alternative_statecraft.txt
@@ -1,0 +1,7 @@
+tr_statecraft_adopt = {
+	unlocks_agenda = agenda_departmental_efficiency
+	modifier = {
+		country_edict_fund_add = 45 # Europe: replaced from 50
+		country_edict_fund_mult = 0.1 # Europe: added
+	}
+}

--- a/europe/common/traditions/99_alternative_subterfuge.txt
+++ b/europe/common/traditions/99_alternative_subterfuge.txt
@@ -1,0 +1,35 @@
+tr_subterfuge_information_security = {
+	modifier = {
+		intel_encryption_add = 2 # Europe: increased from 1
+		#ship_evasion_add = 5 # Europe: removed
+	}
+
+	ai_weight = {
+		factor = 5000
+	}
+}
+
+tr_subterfuge_operational_security = {
+	modifier = {
+		intel_decryption_add = 1
+		espionage_operation_skill_add = 2
+		#ship_tracking_add = 10 # Europe: removed
+	}
+
+	tradition_swap = {
+		name = tr_subterfuge_operational_security_gestalt
+		inherit_effects = yes
+		inherit_icon = yes
+		trigger = {
+			is_gestalt = yes
+		}
+
+		weight = {
+			factor = 1
+		}
+	}
+
+	ai_weight = {
+		factor = 5000
+	}
+}

--- a/europe/common/traditions/99_alternative_supremacy.txt
+++ b/europe/common/traditions/99_alternative_supremacy.txt
@@ -20,6 +20,43 @@ tr_supremacy_overwhelming_force = {
 	}
 }
 
+tr_supremacy_master_shipwrights = {
+	modifier = {
+		starbase_shipyard_build_speed_mult = 0.25
+		country_ship_upgrade_cost_mult = -0.1 # Europe: added
+	}
+
+	tradition_swap = {
+		name = tr_supremacy_master_shipwrights_machine
+		inherit_effects = yes
+		inherit_icon = yes
+		trigger = {
+			is_machine_empire = yes
+		}
+
+		weight = {
+			factor = 1
+		}
+	}
+
+	tradition_swap = {
+		name = tr_supremacy_master_shipwrights_hive
+		inherit_effects = yes
+		inherit_icon = yes
+		trigger = {
+			is_hive_empire = yes
+		}
+
+		weight = {
+			factor = 1
+		}
+	}
+
+	ai_weight = {
+		factor = 1000
+	}
+}
+
 tr_supremacy_war_games = {
 	possible = {
 		has_tradition = tr_supremacy_master_shipwrights

--- a/europe/common/traditions/99_alternative_synchronicity.txt
+++ b/europe/common/traditions/99_alternative_synchronicity.txt
@@ -1,6 +1,6 @@
 tr_synchronicity_cloned_organs = {
 	modifier = {
-		leader_lifespan_add = 20 # Europe: increased from 10
+		leader_lifespan_add = 10
 		negative_traits_country = -1
 	}
 
@@ -14,7 +14,7 @@ tr_synchronicity_cloned_organs = {
 		}
 		custom_tooltip = tr_synchronicity_self_preservation_desc
 		modifier = { # Europe: added
-			leader_lifespan_add = 20
+			leader_lifespan_add = 10
 			negative_traits_country = -1
 		}
 		weight = {
@@ -27,7 +27,7 @@ tr_synchronicity_cloned_organs = {
 		# gain unity per pop necrophaged
 		custom_tooltip = tr_synchronicity_unity_of_mind_desc
 		modifier = { # Europe: added
-			leader_lifespan_add = 20
+			leader_lifespan_add = 10
 			negative_traits_country = -1
 		}
 		trigger = {

--- a/europe/common/traits/99_alternative_admiral_traits.txt
+++ b/europe/common/traits/99_alternative_admiral_traits.txt
@@ -1,0 +1,65 @@
+leader_trait_armorer = {
+	leader_trait_type = destiny
+	inline_script = {
+		script = trait/icon
+		CLASS = commander
+		ICON = GFX_leader_trait_armorer
+		RARITY = paragon
+		COUNCIL = yes
+		TIER = none
+	}
+	councilor_modifier = {
+		# Europe: switched bonuses of Genius Armorer and Resilient Commander (works because of how much weaker the latter is compared to the former)
+		ship_hull_mult = 0.25
+		ship_hull_regen_add_perc = 0.02
+		#ship_shield_add = 100
+		#ship_armor_add = 100
+		#ship_armor_hardening_add = 0.2
+		#ship_shield_hardening_add = 0.2
+	}
+	leader_potential_add = {
+		has_paragon_dlc = yes
+		has_trait = subclass_commander_councilor
+	}
+	leader_class = { commander }
+	selectable_weight = {
+		weight = @subclass_trait_weight
+		inline_script = paragon/council_weight_mult
+	}
+	background_icon = GFX_leader_background_destiny_1
+}
+
+leader_trait_destiny_engineer = {
+	leader_trait_type = destiny
+	inline_script = {
+		script = trait/icon
+		CLASS = commander
+		ICON = GFX_leader_trait_engineer
+		RARITY = paragon
+		COUNCIL = no
+		TIER = none
+	}
+	fleet_modifier = {
+		# Europe: switched bonuses of Genius Armorer and Resilient Commander (works because of how much weaker the latter is compared to the former)
+		ship_shield_mult = 0.2 # Switched from flat bonus to not disproportionately favor smaller ships
+		ship_armor_mult = 0.2 # Switched from flat bonus to not disproportionately favor smaller ships
+		ship_armor_hardening_add = 0.2
+		ship_shield_hardening_add = 0.2
+		#ship_hull_mult = 0.25
+		#ship_hull_regen_add_perc = 0.02
+	}
+	leader_potential_add = {
+		has_paragon_dlc = yes
+		has_trait = subclass_commander_admiral
+	}
+	leader_class = { commander }
+	selectable_weight = {
+		weight = @subclass_trait_weight
+		inline_script = paragon/pilot_weight_mult
+		inline_script = {
+			script = paragon/subclass_weight_mult
+			SUBCLASS = commander_admiral
+		}
+	}
+	background_icon = GFX_leader_background_destiny_1
+}


### PR DESCRIPTION
- Genius Armorer now gives +25% Ship Hull Points and +2% Daily Hull Regeneration instead of bonus Armor Hardening, Shield Hardening, Shield Points, and Armor Points. The new bonuses are the (old) effects of the Resilient Commander trait, but applied empire-wide instead of fleetwide.
- Resilient Commander now gives +20% Ship Shield Points, +20% Ship Armor Points, +20% Armor Hardening, and +20% Shield Hardening. These are mostly the (old) effects of Genius Armorer, but applied to a single fleet instead of empire-wide.