### PR TITLE
fix: bugged planetary deposits

### DIFF
--- a/europe/common/deposits/99_deposits_altered.txt
+++ b/europe/common/deposits/99_deposits_altered.txt
@@ -1,0 +1,327 @@
+## Possible Deposit Variables ##
+# resources, resource and amount
+# potential trigger (planet scope)
+# blocked_modifier - applied to planet
+# constant_modifier - applied to planet always
+# station = station class in orbit to gather
+# blocker_swap_types = {}
+# all_blocker_swap_types = yes/no
+# use_weights_for_blocker_swap_types = yes/no
+# terraforming_swap_types = { }
+# should_swap_deposit_on_terraforming = yes/no
+# all_terraforming_swap_types = yes/no
+# use_weights_for_terraforming_swap_types = yes/no
+
+@high = 16
+@med = 8
+@low = 4
+
+@high_rare = 0.5
+@mid_rare = 0.25
+@low_rare = 0.1
+
+@planet_type_bonus = 1.5
+
+#################################
+#### Event Planetary Deposits ###
+#################################
+
+# Combining the two planet_modifier sections into one
+d_metal_boneyard = {
+	is_for_colonizable = yes
+	category = deposit_cat_rare
+
+	planet_modifier = {
+		district_mining_max = 4
+		planet_jobs_society_research_produces_mult = 0.10
+	}
+
+	triggered_planet_modifier = {
+		potential = {
+			always = yes
+		}
+		district_mining_max = 4
+		mult = value:district_amount_mastery_of_nature
+	}
+
+	drop_weight = {
+		weight = 0
+	}
+}
+
+# Combining the two planet_modifier sections into one
+d_organic_landfill = {
+	is_for_colonizable = yes
+	category = deposit_cat_rare
+	icon = d_organic_landfill
+
+	planet_modifier = {
+		district_generator_max = 4
+		planet_jobs_society_research_produces_mult = 0.10
+	}
+
+	triggered_planet_modifier = {
+		potential = {
+			always = yes
+		}
+		district_generator_max = 4
+		mult = value:district_amount_mastery_of_nature
+	}
+
+	drop_weight = {
+		weight = 0
+	}
+}
+
+# Combining the two planet_modifier sections into one
+d_nanosands = {
+	is_for_colonizable = yes
+	category = deposit_cat_rare
+
+	icon = d_dust_desert
+
+	planet_modifier = {
+		district_mining_max = 2
+		planet_max_districts_add = 2
+	}
+
+	triggered_planet_modifier = {
+		potential = {
+			always = yes
+		}
+		district_mining_max = 2
+		mult = value:district_amount_mastery_of_nature
+	}
+
+	drop_weight = {
+		weight = 0
+		#Set from anomaly
+	}
+}
+
+# Combining the two planet_modifier sections into one
+d_polaris_city = {
+	is_for_colonizable = yes
+	icon = "d_station_junk"
+	category = deposit_cat_rare
+
+	planet_modifier = {
+		district_mining_max = 3
+		planet_district_industrial_build_speed_mult = 0.1
+	}
+
+	triggered_planet_modifier = {
+		potential = {
+			always = yes
+		}
+		district_mining_max = 3
+		mult = value:district_amount_mastery_of_nature
+	}
+
+	drop_weight = {
+		weight = 0
+	}
+}
+
+# Combining the two planet_modifier sections into one
+d_nano_corpses = {
+	is_for_colonizable = yes
+	category = deposit_cat_rare
+	icon = d_nanite_corpses
+
+	planet_modifier = {
+		district_mining_max = 3
+		building_crystal_mines_max = 2
+	}
+
+	triggered_planet_modifier = {
+		potential = {
+			always = yes
+		}
+		district_mining_max = 3
+		mult = value:district_amount_mastery_of_nature
+	}
+
+	drop_weight = {
+		weight = 0
+	}
+}
+
+# Combining the two planet_modifier sections into one
+d_dayside_farm = {
+	is_for_colonizable = yes
+	category = deposit_cat_rare
+
+	icon = d_solar_array
+
+	planet_modifier = {
+		district_generator_max = 6
+		planet_jobs_energy_produces_mult = 0.30
+	}
+
+	triggered_planet_modifier = {
+		potential = {
+			always = yes
+		}
+		district_generator_max = 6
+		mult = value:district_amount_mastery_of_nature
+	}
+
+	# Tidal Lock knowledge turns dayside farms twice as powerful
+	triggered_planet_modifier = {
+		potential = {
+			exists = owner
+			owner = { has_country_flag = tidal_lock_knowledge }
+		}
+		district_generator_max = 6
+		mult = value:district_amount_mastery_of_nature
+		planet_jobs_energy_produces_mult = 0.30
+	}
+
+	drop_weight = {
+		weight = 0
+	}
+}
+
+# Combining the two planet_modifier sections into one
+d_metallic_puddles = {
+	is_for_colonizable = yes
+	category = deposit_cat_rare
+
+	icon = d_fertile_lands
+
+	planet_modifier = {
+		district_farming_max = 3
+		job_puddle_technician_add = 1
+	}
+
+	triggered_planet_modifier = {
+		potential = {
+			always = yes
+		}
+		district_farming_max = 3
+		mult = value:district_amount_mastery_of_nature
+	}
+
+	drop_weight = {
+		weight = 0
+	}
+}
+
+# Combining the two planet_modifier sections into one
+d_metallic_puddles_gestalt = {
+	is_for_colonizable = yes
+	category = deposit_cat_rare
+
+	icon = d_fertile_lands
+
+	planet_modifier = {
+		district_farming_max = 3
+		job_puddle_technician_drone_add = 1
+	}
+
+	triggered_planet_modifier = {
+		potential = {
+			always = yes
+		}
+		district_farming_max = 3
+		mult = value:district_amount_mastery_of_nature
+	}
+
+	drop_weight = {
+		weight = 0
+	}
+}
+
+#############################
+#### Federations Deposits ###
+#############################
+
+# Combining the two planet_modifier sections into one
+d_project_cornucopia = {
+	is_for_colonizable = yes
+	category = deposit_cat_rare
+
+	icon = d_mining_tunnels
+
+	potential = { always = no }
+
+	planet_modifier = {
+		district_mining_max = 4
+		planet_jobs_minerals_produces_mult = 0.05
+		pop_environment_tolerance = -0.2
+	}
+
+	triggered_planet_modifier = {
+		potential = {
+			always = yes
+		}
+		district_mining_max = 4
+		mult = value:district_amount_mastery_of_nature
+	}
+
+	drop_weight = {
+		weight = 0
+	}
+}
+
+# Combining the two planet_modifier sections into one
+d_disco_planet = {
+	is_for_colonizable = yes
+	category = deposit_cat_rare
+
+	icon = d_tradestation_interior
+
+	planet_modifier = {
+		planet_amenities_mult = 0.2
+		building_gas_extractors_max = 1
+		pop_growth_speed = 0.15
+	}
+
+	drop_weight = {
+		weight = 0
+	}
+}
+
+# Combining the two planet_modifier sections into one
+d_disco_planet2 = {
+	is_for_colonizable = yes
+	category = deposit_cat_rare
+
+	icon = d_tradestation_interior
+
+	planet_modifier = {
+		planet_amenities_mult = 0.2
+		pop_growth_speed = 0.15
+	}
+
+	drop_weight = {
+		weight = 0
+	}
+}
+
+#########################
+#### Paragon Deposits ###
+#########################
+
+# Combining the two planet_modifier sections into one
+d_volcanic_active_planet = { #Unstable Planet
+	is_for_colonizable = yes
+	icon = d_mineral_striations
+	category = deposit_cat_rare
+
+	planet_modifier = {
+		district_mining_max = 3
+		building_mote_harvesters_max = 1
+	}
+
+	triggered_planet_modifier = {
+		potential = {
+			always = yes
+		}
+		district_mining_max = 3
+		mult = value:district_amount_mastery_of_nature
+	}
+
+	potential = { always = no }
+}


### PR DESCRIPTION
Some of the planetary deposits are bugged by having two planet_modifier = { } sections, which results in the second planet_modifier overwriting the first one.

Fix is to merge the multiple planet_modifier sections into one.