### PR TITLE
changes: requested mod changes from moderators

### DIFF
--- a/4xGames/common/defines/99_alternative_defines.txt
+++ b/4xGames/common/defines/99_alternative_defines.txt
@@ -23,6 +23,8 @@
 
 	NEconomy = {
 
+		CLAIM_COST_DISTANCE						= 75.0	# Influence cost of claim increase per hyperjump away
+
 		MARKET_FLUCTUATION_ABOVE_BASE_PRICE		= 0.3	# Space_Opera: 1 Base fluctuation when trading a resource' base amount if price is > 0
 		MARKET_FLUCTUATION_BELOW_BASE_PRICE		= 0.1	# Space_Opera: 0.2 Base fluctuation when trading a resource' base amount if price is < 0
 		MARKET_MIN_FLUCTUATION_FROM_BASE_PRICE	= -90	# Space_Opera: -80 Min fluctuation from base price

--- a/4xGames/common/diplomatic_actions/99_insult_warning_actions.txt
+++ b/4xGames/common/diplomatic_actions/99_insult_warning_actions.txt
@@ -77,10 +77,20 @@ action_insult = {
 				flag = IW_warned_2_by@root
 				days = 180
 			}
+			# Remind the player being threatened that they can now be declared on by the empire threatening them
+			country_event = {
+				id = 4xGames.7
+				days = 91
+			}
 		}
 		set_timed_country_flag = {
 			flag = IW_warned_cooldown@from
 			days = 540
+		}
+		# Remind the player who has threatened an empire that they can now declare war on the empire they threatened
+		country_event = {
+			id = 4xGames.6
+			days = 91
 		}
 		if = {
 			limit = {

--- a/4xGames/common/scripted_variables/99_scripted_variables.txt
+++ b/4xGames/common/scripted_variables/99_scripted_variables.txt
@@ -1,0 +1,7 @@
+﻿### MARAUDERS
+@largemercallow = 18000             # Doubled cost. Was 9000
+@largemerccost = -18000             # Doubled cost. Was -9000
+@mediummercallow = 13000            # Doubled cost. Was 6500
+@mediummerccost = -13000            # Doubled cost. Was -6500
+@smallmercallow = 8000              # Doubled cost. Was 4000
+@smallmerccost = -8000              # Doubled cost. Was -4000

--- a/4xGames/events/99_new_events.txt
+++ b/4xGames/events/99_new_events.txt
@@ -87,3 +87,53 @@ ship_event = {
 		}
 	}
 }
+
+# Pop-up to remind the player they can now declare war against the empire they threatened
+country_event = {
+	id = 4xGames.6
+
+	title = 4xGames.6.name
+	desc = 4xGames.6.desc
+
+	picture = GFX_evt_fallen_empire_awakes
+	show_sound = event_alien_signal
+
+	is_triggered_only = yes
+
+	trigger = {
+		owner = {
+			is_ai = no
+		}
+	}
+
+	immediate = {}
+
+	option = {
+		name = 4xGames.6.a
+	}
+}
+
+# Pop-up to remind the player they can now be attacked by the empire who threatened them
+country_event = {
+	id = 4xGames.7
+
+	title = 4xGames.7.name
+	desc = 4xGames.7.desc
+
+	picture = GFX_evt_fallen_empire_awakes
+	show_sound = event_alien_signal
+
+	is_triggered_only = yes
+
+	trigger = {
+		owner = {
+			is_ai = no
+		}
+	}
+
+	immediate = {}
+
+	option = {
+		name = 4xGames.7.a
+	}
+}

--- a/4xGames/localisation/english/sopera_l_english.yml
+++ b/4xGames/localisation/english/sopera_l_english.yml
@@ -137,3 +137,17 @@
  trade_action_r_zro_crystal: "£zro_crystal£ $r_zro_crystal$"
  trade_action_r_zro_crystal_desc: "Trade away our £zro_crystal£ $r_zro_crystal$ relic."
 
+# Renaming insults to Threaten war
+ ACTION_INSULT_TITLE:0 "Threaten War"
+ ACTION_INSULT_DESC:2 "Threatening to declare war against them will greatly reduce their Opinion and Trust of us.[Actor.GetCreativeInsultTooltip]"
+ ACTION_INSULT_OFFER_DESC:0 "Wanton abuse like this cannot be overlooked. Our relationship with §H[Actor.GetName]§! has declined, and we will be able to declare war against them after 3 months."
+
+# Pop-up event reminding the player who threatened another empire that they can now declare war against them
+ 4xGames.6.name: "You can now declare war"
+ 4xGames.6.desc: "This is a friendly reminder telling you that you can now declare war against the empire you threatened 3 months ago. However, you only have 3 months to declare the war before the opportunity passes."
+ 4xGames.6.a: "The drums of war are beating, and we must answer the call."
+
+# Pop-up event reminding the player who has been threatened that they can now be declared against by the empire who threatened them
+ 4xGames.7.name: "They can now declare war against us"
+ 4xGames.7.desc: "This is a cautious reminder warning you that the empire who threatened you 3 months ago are now able to declare war against you. However, they will only have 3 months to declare the war before theit opportunity passes."
+ 4xGames.7.a: "War is coming, whether we are ready or not."


### PR DESCRIPTION
Requested mod changes from the moderators. Changes made:

- Influence cost of claims now increases by 75 per hyperlane jump away instead of 25
- Hiring cost of marauder fleets has been doubled
- The "Insult" diplomatic action has been renamed to "Threaten War"
- A pop-up event now appears for both the empire threatening war and the empire being threatened, that reminds them that the war can now be declared